### PR TITLE
Automate code style

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Build Setup
 
-``` bash
+```bash
 # install dependencies
 npm install
 
@@ -19,3 +19,10 @@ npm run build --report
 ```
 
 For a detailed explanation on how things work, check out the [guide](http://vuejs-templates.github.io/webpack/) and [docs for vue-loader](http://vuejs.github.io/vue-loader).
+
+## Code Style
+
+Code style is automated using Prettier. Using an editor extension that formats on save is recommended:
+
+- https://github.com/jonlabelle/SublimeJsPrettier
+- https://github.com/prettier/prettier-vscode

--- a/package.json
+++ b/package.json
@@ -58,5 +58,10 @@
     "> 1%",
     "last 2 versions",
     "not ie <= 8"
-  ]
+  ],
+  "prettier": {
+    "printWidth": 100,
+    "semi": false,
+    "singleQuote": true
+  }
 }

--- a/src/Domain/Frame/FrameCleaner.js
+++ b/src/Domain/Frame/FrameCleaner.js
@@ -14,24 +14,24 @@ export default class FrameCleaner {
    * @param frames
    * @returns {Array}
    */
-	static cleanFrames(previousFrame, frames) {
-		if(!frames || frames.length == 0) return;
+  static cleanFrames(previousFrame, frames) {
+    if (!frames || frames.length == 0) return
 
-		var newFrames = [];
+    var newFrames = []
 
-		var frame = frames.shift();
-		frame = FrameCleaner.cleanFrame(previousFrame, frame);
+    var frame = frames.shift()
+    frame = FrameCleaner.cleanFrame(previousFrame, frame)
 
-		if(frame.length > 0) {
-			newFrames.push(frame);
+    if (frame.length > 0) {
+      newFrames.push(frame)
 
-			if(frames.length > 0) {
-				Array.prototype.push.apply(newFrames, FrameCleaner.cleanFrames(frame, frames));
-			}
-		}
+      if (frames.length > 0) {
+        Array.prototype.push.apply(newFrames, FrameCleaner.cleanFrames(frame, frames))
+      }
+    }
 
-		return newFrames;
-	}
+    return newFrames
+  }
 
   /**
    * Removes any nodes that are not possible based on the previous frame
@@ -39,14 +39,13 @@ export default class FrameCleaner {
    * @param frame
    * @returns {*}
    */
-	static cleanFrame(previousFrame, frame) {
-		var i = frame.length;
+  static cleanFrame(previousFrame, frame) {
+    var i = frame.length
 
-		while(i--)
-			if(!FrameCleaner.nodePossible(previousFrame, frame[i])) frame.splice(i, 1);
+    while (i--) if (!FrameCleaner.nodePossible(previousFrame, frame[i])) frame.splice(i, 1)
 
-		return frame;
-	}
+    return frame
+  }
 
   /**
    * Checks if the node is adjacent or diagonal to any nodes from the previous frame
@@ -54,14 +53,13 @@ export default class FrameCleaner {
    * @param node
    * @returns {boolean}
    */
-	static nodePossible(previousFrame, node) {
-		var i = previousFrame.length;
+  static nodePossible(previousFrame, node) {
+    var i = previousFrame.length
 
-		while(i--)
-			if(FrameCleaner.touching(previousFrame[i], node)) return true;
+    while (i--) if (FrameCleaner.touching(previousFrame[i], node)) return true
 
-		return false;
-	}
+    return false
+  }
 
   /**
    * Checks if a node is adjacent or diagonal to another node
@@ -69,13 +67,13 @@ export default class FrameCleaner {
    * @param node2
    * @returns {boolean}
    */
-	static touching(node1, node2) {
-		if(Math.abs(node1.x - node2.x) <= 1 && Math.abs(node1.y - node2.y) <= 1) {
-			return true;
-		}
+  static touching(node1, node2) {
+    if (Math.abs(node1.x - node2.x) <= 1 && Math.abs(node1.y - node2.y) <= 1) {
+      return true
+    }
 
-		return false;
-	}
+    return false
+  }
 
   /**
    * Checks if two frames have the same nodes set
@@ -83,14 +81,14 @@ export default class FrameCleaner {
    * @param frame2
    * @returns {boolean}
    */
-	static compareFrames(frame1, frame2) {
-		var equal = true;
+  static compareFrames(frame1, frame2) {
+    var equal = true
 
-		if(frame1.length != frame2.length) return false;
+    if (frame1.length != frame2.length) return false
 
-		var i = frame1.length;
-		while(i--) equal &= (frame1[i].x == frame2[i].x && frame1[i].y == frame2[i].y);
+    var i = frame1.length
+    while (i--) equal &= frame1[i].x == frame2[i].x && frame1[i].y == frame2[i].y
 
-		return equal;
-	}
+    return equal
+  }
 }

--- a/src/Domain/Grid/Grid.js
+++ b/src/Domain/Grid/Grid.js
@@ -2,73 +2,71 @@ import Utils from '@/Domain/Utils'
 import Vue from 'vue'
 
 export default class Grid {
+  constructor(width, height, def) {
+    this.width = width
+    this.height = height
+    this.grid = Utils.createArray(height, width)
+    this.gridCached = false
 
-	constructor (width, height, def) {
-		this.width = width;
-		this.height = height;
-		this.grid = Utils.createArray(height, width);
-		this.gridCached = false;
+    var x = width
+    var y = height
 
-		var x = width;
-		var y = height;
+    while (y--) {
+      while (x--) this.setGridValue(x, y, Vue.util.extend({}, def)) // Might cause issue, not sure how deep this extend copies
+      x = width
+    }
 
-		while(y--) {
-			while(x--) this.setGridValue(x, y, Vue.util.extend({}, def)); // Might cause issue, not sure how deep this extend copies
-			x = width;
-		}
+    this.getFormattedGrid()
+  }
 
-		this.getFormattedGrid();
-	}
+  setGridValue(x, y, value) {
+    if (!this.withinBounds(x, y)) {
+      console.error('Tried to set grid value out of bounds')
+      return
+    }
 
-	setGridValue(x, y, value) {
-		if(!this.withinBounds(x, y)) {
-			console.error('Tried to set grid value out of bounds');
-			return;
-		}
+    this.grid[y][x] = value
+    this.gridCached = false
+  }
 
-		this.grid[y][x] = value;
-		this.gridCached = false;
-	}
+  getGridValue(x, y) {
+    if (!this.withinBounds(x, y)) {
+      console.error('Tried to get grid value out of bounds')
+      return
+    }
 
-	getGridValue(x, y) {
-		if(!this.withinBounds(x, y)) {
-			console.error('Tried to get grid value out of bounds');
-			return;
-		}
+    return this.grid[y][x]
+  }
 
-		return this.grid[y][x];
-	}
+  getFormattedGrid() {
+    var grid = []
+    if (this.gridCached) return this.gridCached
 
-	getFormattedGrid() {
-		var grid = [];
-		if(this.gridCached) return this.gridCached;
+    var x = this.width
+    var y = this.height
 
-		var x = this.width;
-		var y = this.height;
+    while (y--) {
+      var row = {
+        row: y,
+        columns: []
+      }
 
-		while(y--) {
-			var row = {
-				row : y,
-				columns : []
-			}
+      while (x--) {
+        row.columns[x] = {
+          row: y,
+          column: x,
+          val: this.getGridValue(x, y)
+        }
+      }
+      x = this.width
+      grid[y] = row
+    }
 
-			while(x--) {
-				row.columns[x] = {
-					row: y,
-					column: x,
-					val: this.getGridValue(x, y),
-				}
-			} 
-			x = this.width;
-			grid[y] = row;
-		}
+    this.formattedGrid = grid
+    return grid
+  }
 
-		this.formattedGrid = grid;
-		return grid;
-	}
-
-	withinBounds(x, y) {
-		return !(x < 0 || x >= this.width || y < 0 || y >= this.height);
-	}
-
+  withinBounds(x, y) {
+    return !(x < 0 || x >= this.width || y < 0 || y >= this.height)
+  }
 }

--- a/src/Domain/Utils.js
+++ b/src/Domain/Utils.js
@@ -1,13 +1,13 @@
 export default class Utils {
-	static createArray(length) {
+  static createArray(length) {
     var arr = new Array(length || 0),
-        i = length;
+      i = length
 
     if (arguments.length > 1) {
-        var args = Array.prototype.slice.call(arguments, 1);
-        while(i--) arr[length-1 - i] = this.createArray.apply(this, args);
+      var args = Array.prototype.slice.call(arguments, 1)
+      while (i--) arr[length - 1 - i] = this.createArray.apply(this, args)
     }
 
-    return arr;
-	}
+    return arr
+  }
 }

--- a/src/components/HomePageComponent.vue
+++ b/src/components/HomePageComponent.vue
@@ -7,13 +7,10 @@
 </template>
 
 <script>
-
-	export default {
-	  name: 'HomePageComponent',
-	  data () {
-	    return {
-	    }
-	  }
-	}
-
+export default {
+  name: 'HomePageComponent',
+  data() {
+    return {}
+  }
+}
 </script>

--- a/src/components/SpellBuilder/NodeComponent.vue
+++ b/src/components/SpellBuilder/NodeComponent.vue
@@ -5,6 +5,6 @@
 <script>
 export default {
   name: 'spell-creator-node',
-  props: {msg: String}
+  props: { msg: String }
 }
 </script>

--- a/src/components/SpellBuilder/Nodes/PlayerNode.vue
+++ b/src/components/SpellBuilder/Nodes/PlayerNode.vue
@@ -4,22 +4,19 @@
 
 <script>
 export default {
-
   name: 'PlayerNode',
 
-  data () {
-    return {
-
-    }
+  data() {
+    return {}
   },
   props: {
-  	row: Number,
-  	column: Number
+    row: Number,
+    column: Number
   },
   methods: {
-  	selected: function() {
-  		this.$emit('playerNodeClick', this.row, this.column)
-  	}
+    selected: function() {
+      this.$emit('playerNodeClick', this.row, this.column)
+    }
   }
 }
 </script>

--- a/src/components/SpellBuilder/Nodes/SpellNode.vue
+++ b/src/components/SpellBuilder/Nodes/SpellNode.vue
@@ -7,32 +7,29 @@
 
 <script>
 export default {
-
   name: 'SpellNode',
   props: {
-  	row: Number,
-  	column: Number,
-  	active: Boolean,
-  	selected: Boolean
+    row: Number,
+    column: Number,
+    active: Boolean,
+    selected: Boolean
   },
-  data () {
-    return {
-
-    }
+  data() {
+    return {}
   },
   methods: {
-  	onClick: function() {
-  		this.$emit('spellNodeClick', this.column, this.row)
-  	}
+    onClick: function() {
+      this.$emit('spellNodeClick', this.column, this.row)
+    }
   }
 }
 </script>
 
 <style lang="css" scoped>
-	.inactive {
-		background-color: #fff
-	}
-	.selected {
-		background-color: #000
-	}
+.inactive {
+  background-color: #fff;
+}
+.selected {
+  background-color: #000;
+}
 </style>

--- a/src/components/SpellBuilder/SpellBuilder.vue
+++ b/src/components/SpellBuilder/SpellBuilder.vue
@@ -51,14 +51,13 @@ import PlayerNode from '@/components/SpellBuilder/Nodes/PlayerNode'
 import SpellNode from '@/components/SpellBuilder/Nodes/SpellNode'
 
 export default {
-
   name: 'SpellBuilder',
 
-  data () {
+  data() {
     return {
-    	gridWidth: 11,
-    	gridHeight: 11,
-    	showGrid: true,
+      gridWidth: 11,
+      gridHeight: 11,
+      showGrid: true,
       displayGrid: [],
       currentFrame: 0,
       frameHasChanges: false,
@@ -70,32 +69,35 @@ export default {
     PlayerNode,
     SpellNode
   },
-  created: function () {
-    this.grid = new Grid(this.gridWidth, this.gridHeight, {component:'SpellNode', active: false, selected: false});
+  created: function() {
+    this.grid = new Grid(this.gridWidth, this.gridHeight, {
+      component: 'SpellNode',
+      active: false,
+      selected: false
+    })
 
     // Place the player in the center and save the first frame as an empty frame
-    var playerPosX = Math.round(this.gridWidth / 2) - 1;
-    var playerPosY = Math.round(this.gridHeight / 2) - 1;
-    this.originNode = {x:playerPosX, y:playerPosY};
-    this.frames.push([]);
+    var playerPosX = Math.round(this.gridWidth / 2) - 1
+    var playerPosY = Math.round(this.gridHeight / 2) - 1
+    this.originNode = { x: playerPosX, y: playerPosY }
+    this.frames.push([])
 
     // Load initial frame and display it
-    this.loadFrame(0);
-    this.displayGrid = this.grid.getFormattedGrid();
+    this.loadFrame(0)
+    this.displayGrid = this.grid.getFormattedGrid()
   },
   methods: {
-
     /**
      * Will be received when a spell node is click
      * Just reverse the selected property of the node
      * Should not receive these for any inactive spell nodes
      * @param x
      * @param y
-     * 
+     *
      */
     onSpellNodeClick(x, y) {
-      var node = this.grid.getGridValue(x,y);
-      node.selected = !node.selected;
+      var node = this.grid.getGridValue(x, y)
+      node.selected = !node.selected
     },
 
     /**
@@ -103,18 +105,18 @@ export default {
      * Useful when loading a new frame and need to enable all the frames around the ones selected in the previous frame
      * stopDuringPlayback, if set to false, this will happen during playback
      */
-  	activateAroundNode(x, y, stopDuringPlayback = true) {
-      if(this.playingBack && stopDuringPlayback) return;
+    activateAroundNode(x, y, stopDuringPlayback = true) {
+      if (this.playingBack && stopDuringPlayback) return
 
-  		this.activateNode(x + 1, y);
-	  	this.activateNode(x - 1, y);
-	  	this.activateNode(x, y + 1);
-	  	this.activateNode(x, y - 1);
-	  	this.activateNode(x + 1, y + 1);
-	  	this.activateNode(x + 1, y - 1);
-	  	this.activateNode(x - 1, y + 1);
-	  	this.activateNode(x - 1, y - 1);
-  	},
+      this.activateNode(x + 1, y)
+      this.activateNode(x - 1, y)
+      this.activateNode(x, y + 1)
+      this.activateNode(x, y - 1)
+      this.activateNode(x + 1, y + 1)
+      this.activateNode(x + 1, y - 1)
+      this.activateNode(x - 1, y + 1)
+      this.activateNode(x - 1, y - 1)
+    },
 
     /**
      * Activates a node, making it clickable
@@ -124,16 +126,16 @@ export default {
      * @param component
      * @param stopDuringPlayback, if set to false, this will happen during playback
      */
-  	activateNode(x, y, component = 'SpellNode', stopDuringPlayback = true) {
-      if(!this.grid.withinBounds(x, y)) return;
-      if(this.playingBack && stopDuringPlayback) return;
+    activateNode(x, y, component = 'SpellNode', stopDuringPlayback = true) {
+      if (!this.grid.withinBounds(x, y)) return
+      if (this.playingBack && stopDuringPlayback) return
 
-  		var node = this.grid.getGridValue(x,y);
-  		node.component = component;
-  		if(!node.active) {
-  			node.active = true;
-  		}
-  	},
+      var node = this.grid.getGridValue(x, y)
+      node.component = component
+      if (!node.active) {
+        node.active = true
+      }
+    },
 
     /**
      * Sets active and selected properties of a node to true.
@@ -142,26 +144,26 @@ export default {
      * @param y
      */
     selectNode(x, y) {
-      var node = this.grid.getGridValue(x,y);
-      node.active = true;
-      node.selected = true;
+      var node = this.grid.getGridValue(x, y)
+      node.active = true
+      node.selected = true
     },
 
     /**
      * Deselects all nodes and sets them to inactive
      */
     resetGrid() {
-      var x = this.grid.width;
-      var y = this.grid.height;
+      var x = this.grid.width
+      var y = this.grid.height
 
-      while(y--) {
-        while(x--) {
-          var node = this.grid.getGridValue(x,y);
-          node.active = false;
-          node.selected = false;
-          node.component = 'SpellNode';
+      while (y--) {
+        while (x--) {
+          var node = this.grid.getGridValue(x, y)
+          node.active = false
+          node.selected = false
+          node.component = 'SpellNode'
         }
-        x = this.grid.width;
+        x = this.grid.width
       }
     },
 
@@ -173,22 +175,22 @@ export default {
      * @returns {Array}
      */
     getFrameFromGrid() {
-      var frame = [];
-      var x = this.grid.width;
-      var y = this.grid.height;
+      var frame = []
+      var x = this.grid.width
+      var y = this.grid.height
 
-      while(y--) {
-        while(x--) {
-          var node = this.grid.getGridValue(x,y);
+      while (y--) {
+        while (x--) {
+          var node = this.grid.getGridValue(x, y)
 
-          if(node.selected && node.component == 'SpellNode') {
-            frame.push({x:x, y:y});
+          if (node.selected && node.component == 'SpellNode') {
+            frame.push({ x: x, y: y })
           }
         }
-        x = this.grid.width;
+        x = this.grid.width
       }
 
-      return frame;
+      return frame
     },
 
     /**
@@ -201,30 +203,31 @@ export default {
      * @returns {*}
      */
     saveFrame(frameId) {
-      var frame = this.getFrameFromGrid();
+      var frame = this.getFrameFromGrid()
 
-      if(frameId == -1) {
-        frameId = this.frames.push(frame) - 1;
+      if (frameId == -1) {
+        frameId = this.frames.push(frame) - 1
       } else {
-        this.$set(this.frames, frameId, frame);
+        this.$set(this.frames, frameId, frame)
       }
 
       // clean frames
-      if(frameId >= 0) { // no need to clean if it's a new frame
-        let cleanFrom = frameId == 0 ? frameId : frameId - 1;// Want to clean from the previous frame unless we are at the first frame
-        let spliceFrom = frameId == 0 ? 1 : frameId; // Don't splice the first frame
+      if (frameId >= 0) {
+        // no need to clean if it's a new frame
+        let cleanFrom = frameId == 0 ? frameId : frameId - 1 // Want to clean from the previous frame unless we are at the first frame
+        let spliceFrom = frameId == 0 ? 1 : frameId // Don't splice the first frame
 
-        var framesToClean = this.frames.splice(spliceFrom);
-        var cleanFrames = FrameCleaner.cleanFrames(this.frames[cleanFrom], framesToClean);
-        Array.prototype.push.apply(this.frames, cleanFrames);
+        var framesToClean = this.frames.splice(spliceFrom)
+        var cleanFrames = FrameCleaner.cleanFrames(this.frames[cleanFrom], framesToClean)
+        Array.prototype.push.apply(this.frames, cleanFrames)
       }
 
       // If this was a save of an empty frame, this frame, and the ones after are all deleted so load the previous one
-      if(frameId > this.frames.length - 1) {
-        this.loadFrame(this.frames.length - 1);
+      if (frameId > this.frames.length - 1) {
+        this.loadFrame(this.frames.length - 1)
       }
 
-      return frameId;
+      return frameId
     },
 
     /**
@@ -234,48 +237,48 @@ export default {
      * @param frameId
      */
     loadFrame(frameId) {
-      this.resetGrid();
+      this.resetGrid()
 
-      if(frameId > this.frames.length - 1) {
-        frameId = this.frames.length - 1;
+      if (frameId > this.frames.length - 1) {
+        frameId = this.frames.length - 1
       }
 
-      if(frameId < 0) {
-        frameId = 0;
+      if (frameId < 0) {
+        frameId = 0
       }
 
-      var frame = this.frames[frameId] ? this.frames[frameId] : [];
-      var i = frame.length;
+      var frame = this.frames[frameId] ? this.frames[frameId] : []
+      var i = frame.length
 
-      while(i--) {
-        var node = frame[i];
+      while (i--) {
+        var node = frame[i]
         this.selectNode(node.x, node.y)
       }
 
-      if(frameId == 0) {
+      if (frameId == 0) {
         // Special case for the starting frame
-        this.activateNode(this.originNode.x, this.originNode.y, 'PlayerNode', false);
-        this.activateAroundNode(this.originNode.x, this.originNode.y);
+        this.activateNode(this.originNode.x, this.originNode.y, 'PlayerNode', false)
+        this.activateAroundNode(this.originNode.x, this.originNode.y)
       } else {
-        var previousFrame = this.frames[frameId - 1];
+        var previousFrame = this.frames[frameId - 1]
 
-        i = previousFrame.length;
+        i = previousFrame.length
         while (i--) {
-          var node = previousFrame[i];
-          this.activateAroundNode(node.x, node.y);
-          this.activateNode(node.x, node.y);
+          var node = previousFrame[i]
+          this.activateAroundNode(node.x, node.y)
+          this.activateNode(node.x, node.y)
         }
       }
 
-      this.currentFrame = frameId;
+      this.currentFrame = frameId
     },
 
     /**
      * Loads the frame before the current frame
      */
     previousFrame() {
-      this.checkForChanges();
-      this.loadFrame(this.currentFrame - 1);
+      this.checkForChanges()
+      this.loadFrame(this.currentFrame - 1)
     },
 
     /**
@@ -283,12 +286,12 @@ export default {
      * If we are currently on the last frame, it will add a new one
      */
     nextFrame() {
-  	  this.checkForChanges();
-      if(this.currentFrame != this.frames.length - 1) {
-        this.loadFrame(this.currentFrame + 1);
+      this.checkForChanges()
+      if (this.currentFrame != this.frames.length - 1) {
+        this.loadFrame(this.currentFrame + 1)
       } else {
-        var newFrameId = this.saveFrame(-1);
-        this.loadFrame(newFrameId);
+        var newFrameId = this.saveFrame(-1)
+        this.loadFrame(newFrameId)
       }
     },
 
@@ -297,17 +300,17 @@ export default {
      * If there are differences, it asks the user if they want to save the changes
      */
     checkForChanges() {
-  	  let frame = this.frames[this.currentFrame];
-  	  if(!FrameCleaner.compareFrames(this.getFrameFromGrid(), frame)) {
-  	    if(confirm("Save changes to current frame?")) {
-  	      this.saveFrame(this.currentFrame);
+      let frame = this.frames[this.currentFrame]
+      if (!FrameCleaner.compareFrames(this.getFrameFromGrid(), frame)) {
+        if (confirm('Save changes to current frame?')) {
+          this.saveFrame(this.currentFrame)
         }
       }
     },
 
     startPlayback() {
-      this.playingBack = true;
-      this.playbackFrame(0);
+      this.playingBack = true
+      this.playbackFrame(0)
     },
 
     /**
@@ -315,24 +318,22 @@ export default {
      * @param frameId
      */
     playbackFrame(frameId) {
-      if(frameId != this.frames.length - 1) {
-        var self = this;
+      if (frameId != this.frames.length - 1) {
+        var self = this
 
-        setTimeout(function(){
-          self.playbackFrame(self.currentFrame + 1);
-        }, 1000);
+        setTimeout(function() {
+          self.playbackFrame(self.currentFrame + 1)
+        }, 1000)
       } else {
-        this.playingBack = false;
+        this.playingBack = false
       }
 
-      this.loadFrame(frameId);
-
+      this.loadFrame(frameId)
     }
   },
   computed: {
-
     frameCount() {
-      return this.frames.length - 1;
+      return this.frames.length - 1
     },
 
     /**
@@ -340,14 +341,14 @@ export default {
      * @returns {Array}
      */
     frameNumbers() {
-      var numbers = [];
-      var keys = this.frames.keys();
+      var numbers = []
+      var keys = this.frames.keys()
 
-      for(let key of keys) {
-        numbers.push(key);
+      for (let key of keys) {
+        numbers.push(key)
       }
 
-      return numbers;
+      return numbers
     },
 
     spellJSON: {
@@ -357,23 +358,23 @@ export default {
        * @returns {string}
        */
       get: function() {
-        let relativeFrames = [];
+        let relativeFrames = []
 
         for (let i = 0; i < this.frames.length; i++) {
-          let relativeFrame = [];
-          let frame = this.frames[i];
+          let relativeFrame = []
+          let frame = this.frames[i]
 
-          for(let n = 0; n < frame.length; n++) {
-            let node = frame[n];
+          for (let n = 0; n < frame.length; n++) {
+            let node = frame[n]
             let relativeNode = {
-              x:node.x - this.originNode.x,
-              y:node.y - this.originNode.y
-            };
+              x: node.x - this.originNode.x,
+              y: node.y - this.originNode.y
+            }
 
-            relativeFrame.push(relativeNode);
+            relativeFrame.push(relativeNode)
           }
 
-          relativeFrames.push(relativeFrame);
+          relativeFrames.push(relativeFrame)
         }
 
         return JSON.stringify(relativeFrames)
@@ -384,29 +385,29 @@ export default {
        * @param spell
        */
       set: function(spell) {
-        let frames = [];
-        let relativeFrames = JSON.parse(spell);
+        let frames = []
+        let relativeFrames = JSON.parse(spell)
 
         for (let i = 0; i < relativeFrames.length; i++) {
-          let frame = [];
-          let relativeFrame = relativeFrames[i];
+          let frame = []
+          let relativeFrame = relativeFrames[i]
 
-          for(let n = 0; n < relativeFrame.length; n++) {
-            let relativeNode = relativeFrame[n];
+          for (let n = 0; n < relativeFrame.length; n++) {
+            let relativeNode = relativeFrame[n]
             let node = {
-              x:relativeNode.x + this.originNode.x,
-              y:relativeNode.y + this.originNode.y
-            };
+              x: relativeNode.x + this.originNode.x,
+              y: relativeNode.y + this.originNode.y
+            }
 
             frame.push(node)
           }
 
-          frames.push(frame);
+          frames.push(frame)
         }
 
-        this.frames = frames;
+        this.frames = frames
 
-        this.loadFrame(0);
+        this.loadFrame(0)
       }
     }
   }
@@ -414,12 +415,12 @@ export default {
 </script>
 
 <style lang="css" scoped>
-  .spellLoader {
-    width:100%;
-    height:200px;
-  }
-  .selectedFrame {
-    background-color: green;
-    color:white;
-  }
+.spellLoader {
+  width: 100%;
+  height: 200px;
+}
+.selectedFrame {
+  background-color: green;
+  color: white;
+}
 </style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -4,20 +4,19 @@ import HomePageComponent from '@/components/HomePageComponent'
 
 import SpellBuilder from '@/components/SpellBuilder/SpellBuilder'
 
-
 Vue.use(Router)
 
 export default new Router({
   routes: [
     {
-    	path: '/',
+      path: '/',
       name: 'Home',
       component: HomePageComponent
     },
     {
-    	path:'/SpellBuilder/',
-    	name:'SpellBuilder',
-    	component: SpellBuilder
+      path: '/SpellBuilder/',
+      name: 'SpellBuilder',
+      component: SpellBuilder
     }
   ]
 })


### PR DESCRIPTION
Prettier makes JS code style a non-issue. Grab the editor extension out of the README and set it up to format on save and never worry about a semicolon or trailing comma again.

It's configurable in package.json. Options are here: https://prettier.io/docs/en/options.html