### PR TITLE
Now saves whenever a change is made and confirms after cleaning

### DIFF
--- a/src/Domain/Frame/FrameCleaner.js
+++ b/src/Domain/Frame/FrameCleaner.js
@@ -91,4 +91,21 @@ export default class FrameCleaner {
 
     return equal
   }
+
+  /**
+   * Compares two sets of frames
+   * @param  {array} frameSet1
+   * @param  {array} frameSet2
+   * @return {boolean}
+   */
+  static compareFrameSets(frameSet1, frameSet2) {
+    var equal = true
+
+    if (frameSet1.length != frameSet2.length) return false
+
+    var i = frameSet1.length
+    while (i--) equal &= FrameCleaner.compareFrames(frameSet1[i], frameSet2[i])
+
+    return equal
+  }
 }

--- a/src/components/SpellBuilder/SpellBuilder.vue
+++ b/src/components/SpellBuilder/SpellBuilder.vue
@@ -14,8 +14,6 @@
     <div>
       <button @click="previousFrame"
               :disabled="currentFrame == 0 || playingBack">Prev Frame</button>
-      <button @click="saveFrame(currentFrame)"
-              :disabled="playingBack">Save Frame</button>
       <button @click="nextFrame"
               :disabled="playingBack">{{ currentFrame == frameCount ? 'New' : 'Next' }} Frame</button>
     </div>
@@ -28,9 +26,6 @@
             :defaultOptions="{active:false, selected: false}"
             @onNodeEvent="onNodeEvent">
       </grid>
-    </div>
-    <div>
-      Current frame: {{currentFrame}}
     </div>
     <div>
       <textarea v-model="spellJSON" class='spellLoader'></textarea>
@@ -94,6 +89,10 @@ export default {
       if (node.component === 'SpellBuilderSpellNode') {
         if (event === 'click') {
           node.selected = !node.selected
+
+          if (this.saveFrame(this.currentFrame) === false) {
+            node.selected = !node.selected
+          }
         }
       }
     },
@@ -199,26 +198,38 @@ export default {
      * are still possible
      * If the frame is saved with no selected nodes, therefore deleted, it will load the previous node
      * @param frameId
-     * @returns {*}
+     * @returns New frame id or false if the save was canceled
      */
     saveFrame(frameId) {
+      // Deep copy frames into a temp variable so we can rollback save if need be
+      let tempFrames = JSON.parse(JSON.stringify(this.frames))
       var frame = this.getFrameFromGrid()
 
       if (frameId == -1) {
-        frameId = this.frames.push(frame) - 1
+        frameId = tempFrames.push(frame) - 1
       } else {
-        this.$set(this.frames, frameId, frame)
+        tempFrames[frameId] = frame
       }
 
-      // clean frames
-      if (frameId >= 0) {
-        // no need to clean if it's a new frame
+      // clean frames if it is not a new frame
+      if (frameId < this.frames.length) {
         let cleanFrom = frameId == 0 ? frameId : frameId - 1 // Want to clean from the previous frame unless we are at the first frame
         let spliceFrom = frameId == 0 ? 1 : frameId // Don't splice the first frame
+        let cleanCheckFrames = JSON.parse(JSON.stringify(tempFrames)) // Deep copy again so we can tell if changes were made from cleaning
 
-        var framesToClean = this.frames.splice(spliceFrom)
-        var cleanFrames = FrameCleaner.cleanFrames(this.frames[cleanFrom], framesToClean)
-        Array.prototype.push.apply(this.frames, cleanFrames)
+        var framesToClean = cleanCheckFrames.splice(spliceFrom)
+        var cleanFrames = FrameCleaner.cleanFrames(cleanCheckFrames[cleanFrom], framesToClean)
+        Array.prototype.push.apply(cleanCheckFrames, cleanFrames)
+
+        if (FrameCleaner.compareFrameSets(tempFrames, cleanCheckFrames)) {
+          this.frames = cleanCheckFrames
+        } else if (confirm('This will cause changes in later frames, continue?')) {
+          this.frames = cleanCheckFrames
+        } else {
+          return false
+        }
+      } else {
+        this.frames = tempFrames
       }
 
       // If this was a save of an empty frame, this frame, and the ones after are all deleted so load the previous one
@@ -276,7 +287,6 @@ export default {
      * Loads the frame before the current frame
      */
     previousFrame() {
-      this.checkForChanges()
       this.loadFrame(this.currentFrame - 1)
     },
 
@@ -285,25 +295,11 @@ export default {
      * If we are currently on the last frame, it will add a new one
      */
     nextFrame() {
-      this.checkForChanges()
       if (this.currentFrame != this.frames.length - 1) {
         this.loadFrame(this.currentFrame + 1)
       } else {
         var newFrameId = this.saveFrame(-1)
         this.loadFrame(newFrameId)
-      }
-    },
-
-    /**
-     * Compares the current grid to the frame that is saved currentFrame
-     * If there are differences, it asks the user if they want to save the changes
-     */
-    checkForChanges() {
-      let frame = this.frames[this.currentFrame]
-      if (!FrameCleaner.compareFrames(this.getFrameFromGrid(), frame)) {
-        if (confirm('Save changes to current frame?')) {
-          this.saveFrame(this.currentFrame)
-        }
       }
     },
 


### PR DESCRIPTION
Instead of having to save frames, it will now just save the frame when you make a change. 
Also, to make sure that you don't accidentally click a node and cause half your frames to go away. So I added a confirm to make sure you want to make the changes, if said changes affect later frames